### PR TITLE
Fix tests and jest path mapping

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,10 @@
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
     },
+    "moduleNameMapper": {
+      "^@/(.*)$": "<rootDir>/$1",
+      "^src/(.*)$": "<rootDir>/$1"
+    },
     "collectCoverageFrom": [
       "**/*.(t|j)s"
     ],

--- a/src/admin-dashboard/admin-dashboard.controller.spec.ts
+++ b/src/admin-dashboard/admin-dashboard.controller.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AdminDashboardController } from './admin-dashboard.controller';
+import { AdminDashboardService } from './admin-dashboard.service';
 
 describe('AdminDashboardController', () => {
   let controller: AdminDashboardController;
@@ -7,6 +8,7 @@ describe('AdminDashboardController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [AdminDashboardController],
+      providers: [{ provide: AdminDashboardService, useValue: {} }],
     }).compile();
 
     controller = module.get<AdminDashboardController>(AdminDashboardController);

--- a/src/admin-dashboard/admin-dashboard.service.spec.ts
+++ b/src/admin-dashboard/admin-dashboard.service.spec.ts
@@ -1,12 +1,19 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AdminDashboardService } from './admin-dashboard.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { User } from 'src/user/entities/users.entity';
+import { VehicleListing } from 'src/vehicle-listings/entities/vehicle-listing.entity';
 
 describe('AdminDashboardService', () => {
   let service: AdminDashboardService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [AdminDashboardService],
+      providers: [
+        AdminDashboardService,
+        { provide: getRepositoryToken(User), useValue: {} },
+        { provide: getRepositoryToken(VehicleListing), useValue: {} },
+      ],
     }).compile();
 
     service = module.get<AdminDashboardService>(AdminDashboardService);

--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
 
 describe('AuthController', () => {
   let controller: AuthController;
@@ -7,6 +8,7 @@ describe('AuthController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [AuthController],
+      providers: [{ provide: AuthService, useValue: {} }],
     }).compile();
 
     controller = module.get<AuthController>(AuthController);

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -1,12 +1,21 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AuthService } from './auth.service';
+import { JwtService } from '@nestjs/jwt';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { UsersService } from 'src/user/users.service';
+import { UserToken } from '@/user/entities/user-token.entity';
 
 describe('AuthService', () => {
   let service: AuthService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [AuthService],
+      providers: [
+        AuthService,
+        { provide: UsersService, useValue: {} },
+        { provide: JwtService, useValue: { sign: jest.fn() } },
+        { provide: getRepositoryToken(UserToken), useValue: {} },
+      ],
     }).compile();
 
     service = module.get<AuthService>(AuthService);

--- a/src/user/users.controller.spec.ts
+++ b/src/user/users.controller.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { UsersController } from './users.controller';
+import { UsersService } from './users.service';
 
 describe('UserController', () => {
   let controller: UsersController;
@@ -7,6 +8,7 @@ describe('UserController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [UsersController],
+      providers: [{ provide: UsersService, useValue: {} }],
     }).compile();
 
     controller = module.get<UsersController>(UsersController);

--- a/src/vehicle-listings/vehicle-listings.controller.spec.ts
+++ b/src/vehicle-listings/vehicle-listings.controller.spec.ts
@@ -1,6 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { VehicleListingsController } from './vehicle-listings.controller';
 import { VehicleListingsService } from './vehicle-listings.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { VehicleListing } from './entities/vehicle-listing.entity';
 
 describe('VehicleListingsController', () => {
   let controller: VehicleListingsController;
@@ -8,7 +10,10 @@ describe('VehicleListingsController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [VehicleListingsController],
-      providers: [VehicleListingsService],
+      providers: [
+        VehicleListingsService,
+        { provide: getRepositoryToken(VehicleListing), useValue: {} },
+      ],
     }).compile();
 
     controller = module.get<VehicleListingsController>(


### PR DESCRIPTION
## Summary
- add Jest moduleNameMapper for src and @ aliases
- fix unit tests by providing mock dependencies

## Testing
- `npm test`
- `npm run lint` *(fails: unsafe any usage in e2e tests)*

------
https://chatgpt.com/codex/tasks/task_e_683f51f82078832cb873963a69fb8f8b